### PR TITLE
Restyles close icon animation

### DIFF
--- a/src/components/Chatbot/ChatHeader/index.tsx
+++ b/src/components/Chatbot/ChatHeader/index.tsx
@@ -72,7 +72,10 @@ const CloseButton = styled.button`
 
   &:focus,
   &:hover {
-    transform: rotate(135deg);
+    transform: rotate(180deg);
+    background-color: black;
+    opacity: 0.3;
+    border-radius: 50%;
   }
 `;
 


### PR DESCRIPTION
On hover / focus, the close icon will now spin 180deg and show a
circle background around the buttons hitbox.