### PR TITLE
Add motion to MiniChat button and choreograph entrance and exit

### DIFF
--- a/src/components/Chatbot/MiniChat/index.tsx
+++ b/src/components/Chatbot/MiniChat/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled, { css } from 'styled-components/macro';
+import { motion } from 'framer-motion';
 
 import Chat from 'components/icons/Chat';
 
@@ -24,16 +25,37 @@ const buttonCss = css`
   background-color: var(--chat-primary);
 `;
 
+const animation = {
+  initial: {
+    opacity: 0,
+    y: 10,
+  },
+  animate: {
+    opacity: 1,
+    y: 0,
+    transition: {
+      delay: 0.5,
+      duration: 0.4,
+    },
+  },
+  exit: {
+    opacity: 0,
+    y: 10,
+  },
+};
+
 const MiniChat: React.FC<Props> = ({ className, onClick }) => (
-  <button
+  <motion.button
     className={className}
     onClick={onClick}
     css={buttonCss}
     aria-label="Open Chat"
     type="button"
+    tabIndex={0}
+    {...animation}
   >
     <StyledChat />
-  </button>
+  </motion.button>
 );
 
 export default MiniChat;

--- a/src/components/Chatbot/index.tsx
+++ b/src/components/Chatbot/index.tsx
@@ -59,6 +59,7 @@ const animation = {
     x: 0,
     transition: {
       duration: 0.4,
+      delay: 0.25,
     },
   },
   exit: {


### PR DESCRIPTION
This animates the MiniChat to slide up and fade in on mount and exit,
and adds some delays to the MiniChat and Chatbot so that they will fade
in after the previous component has finished animating.